### PR TITLE
Add wrapper style & thumb width settings

### DIFF
--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -79,6 +79,12 @@ const handleClickScrollToTop = () => {
 **style** _`:object`_ = undefined
 滚动容器style。
 
+**wrapperClass** _`:string`_ = undefined
+包裹容器的class。
+
+**wrapperStyle** _`:object`_ = undefined
+包裹容器的style。
+
 **contentClass** _`:string`_ = undefined
 内容容器class，设置display、padding等的地方。
 
@@ -90,6 +96,9 @@ const handleClickScrollToTop = () => {
 
 **thumbMinSize / thumbMaxSize** _`:number`_ = 48 / Infinity  
 设置滚动条的 最小/最大 尺寸。
+
+**thumbWidth** _`:number`_ = 12
+设置滚动条的宽度。
 
 **autoHide** _`:boolean`_ = true  
 开启后，只有当鼠标悬浮于滚动容器上时才会显示滚动条。

--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ Container class, which is generally only used to set the size.
 **style** _`:object`_ = undefined
 Container style.
 
+**wrapperClass** _`:string`_ = undefined
+Wrapper class, the place to set display, padding, etc.
+
+**wrapperStyle** _`:object`_ = undefined
+Wrapper style.
+
 **contentClass** _`:string`_ = undefined
 Content class, the place to set display, padding, etc.
 
@@ -93,6 +99,9 @@ If you need to change the content container to horizontal layout, you can set th
 
 **thumbMinSize / thumbMaxSize** _`:number`_ = 48 / Infinity  
 Sets the minimum/maximum size of the scrollbar.
+
+**thumbWidth** _`:number`_ = 12
+Set the width of the scrollbar thumb.
 
 **autoHide** _`:boolean`_ = true  
 When turned on, the scrollbar will be displayed only when the mouse hovers over the scroll container.

--- a/src/index.vue
+++ b/src/index.vue
@@ -1,5 +1,8 @@
 <template>
-    <div class="scrollbar__wrapper">
+    <div
+        :class="['scrollbar__wrapper', wrapperClass]"
+        :style="wrapperStyle"
+    >
         <div
             ref="wrapperEl"
             class="scrollbar__scroller"
@@ -26,6 +29,7 @@
             :fixedThumb="(thumbType === direction ? false : fixedThumb)"
             :type="thumbType"
             :scrollInfo="thumbType === 'vertical' ? scrollHeightInfo : scrollWidthInfo"
+            :thumbWidth="thumbWidth"
             :wrapperEl="wrapperEl"
         />
     </div>
@@ -47,12 +51,15 @@ import type { Rect } from './useMeasure';
 import useMeasure from './useMeasure';
 
 interface Props extends HTMLAttributes {
+    wrapperClass?: string;
+    wrapperStyle?: StyleValue;
     contentClass?: string;
     contentStyle?: StyleValue;
     /** Set major scroll direction.Will auto set the scroll container element display to 'horizontal' -> 'inline-flex' / 'vertical' -> 'block'('inline-block' if fixedThumb). */
     direction?: 'horizontal' | 'vertical';
     thumbMinSize?: number;
     thumbMaxSize?: number;
+    thumbWidth?: number
     autoHide?: boolean;
     autoHideDelay?: number;
     autoExpand?: boolean;
@@ -72,6 +79,7 @@ const props = withDefaults(defineProps<Props>(), {
     throttleWait: 333,
     thumbMinSize: 48,
     thumbMaxSize: Infinity,
+    thumbWidth: 12
 });
 
 const emit = defineEmits<{
@@ -111,7 +119,7 @@ function updateMaxScrollDistance() { // Recalculate native scrollable distance s
 }
 let scrollWidthInfo = $computed(() => {
     return {
-        thumbSize : nativeMaxScrollLeft ? 
+        thumbSize : nativeMaxScrollLeft ?
             clamp(
                 wrapperRect.width / wrapperEl.scrollWidth *  wrapperRect.width,
                 props.thumbMinSize > wrapperRect.width ? 48 : props.thumbMinSize,

--- a/src/thumb.vue
+++ b/src/thumb.vue
@@ -2,14 +2,14 @@
     <div
         v-show="Boolean(scrollInfo.thumbSize) && (fixedThumb ? isWrapperIntersecting : true)"
         :class="[
-            'scrollbar__thumbPlaceholder', 
-            `scrollbar__thumbPlaceholder--${type}`, 
+            'scrollbar__thumbPlaceholder',
+            `scrollbar__thumbPlaceholder--${type}`,
             {
                 ['scrollbar__thumbPlaceholder--autoHide']: autoHide,
                 ['scrollbar__thumbPlaceholder--autoExpand']: autoExpand,
             }
         ]"
-        :style="{ 
+        :style="{
             width: type === 'horizontal' ? `${scrollInfo.thumbSize}px`: '',
             height: type === 'vertical' ? `${scrollInfo.thumbSize}px` : '',
             position: !shouldFixed ? 'absolute' : 'fixed',
@@ -38,7 +38,7 @@ export default {
 </script>
 <script setup lang="ts">
 import { throttle } from 'lodash-es';
-import { onUnmounted, watch } from 'vue';
+import { computed, onUnmounted, watch } from 'vue';
 
 interface Props {
     type: 'horizontal' | 'vertical';
@@ -52,9 +52,11 @@ interface Props {
         wrapperMainSize: number;
         boundaryDistance: number;
     };
+    thumbWidth?: number;
     wrapperEl: Element;
 }
 const props = defineProps<Props>();
+const computedThumbWidth = computed(() => `${props.thumbWidth ?? 12}px`)
 
 /** <--------------- mouse drag handler ---------------> */
 let autoHideTimer: number | null = null;
@@ -84,7 +86,7 @@ const handlePointerMove = throttle((evt: PointerEvent) => {
 
 const handlePointerEnd = () => {
     startAutoHideTimer();
-    
+
     thumbEl.removeEventListener('pointermove', handlePointerMove);
     thumbEl.removeEventListener('pointerup', handlePointerEnd);
     thumbEl.removeEventListener('pointercancel', handlePointerEnd);
@@ -172,13 +174,13 @@ onUnmounted(clearIO);
         top: 3px;
         right: 0;
 
-        width: 12px;
+        width: v-bind(computedThumbWidth);
     }
     &--horizontal {
         left: 3px;
         bottom: 0;
 
-        height: 12px;
+        height: v-bind(computedThumbWidth);
     }
 
     &--autoHide {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -12,6 +12,14 @@ export interface Rect {
 }
 
 declare const _default: import("vue").DefineComponent<{
+    wrapperClass: {
+        type: any;
+        required: false;
+    };
+    wrapperStyle: {
+        type: StyleValue;
+        required: false;
+    };
     class: {
         type: any;
         required: false;
@@ -47,6 +55,11 @@ declare const _default: import("vue").DefineComponent<{
         required: false;
         default: Infinity;
     };
+    thumbWidth: {
+        type: NumberConstructor;
+        required: false;
+        default: 12;
+    }
     autoHide: {
         type: BooleanConstructor;
         required: false;
@@ -78,12 +91,15 @@ declare const _default: import("vue").DefineComponent<{
     };
 }, {
     props: {
+        wrapperClass?: string | undefined;
+        wrapperStyle?: StyleValue | undefined;
         contentClass?: string | undefined;
         contentStyle?: StyleValue | undefined;
         direction: 'horizontal' | 'vertical';
         fixedThumb?: boolean | undefined;
         thumbMinSize: number;
         thumbMaxSize: number;
+        thumbWidth: number;
         autoHide: boolean;
         autoHideDelay: number;
         autoExpand: boolean;
@@ -100,10 +116,13 @@ declare const _default: import("vue").DefineComponent<{
     style?: StyleValue | undefined;
     contentClass?: string | undefined;
     contentStyle?: StyleValue | undefined;
+    wrapperClass?: string | undefined;
+    wrapperStyle?: StyleValue | undefined;
     direction?: 'horizontal' | 'vertical';
     fixedThumb?: boolean;
     thumbMinSize?: number;
     thumbMaxSize?: number;
+    thumbWidth?: number;
     autoHide?: boolean;
     autoHideDelay?: number;
     autoExpand?: boolean;


### PR DESCRIPTION
## What

Added properties `wrapperStyle` `wrapperClass` and `thumbWidth` to the component, allowing more customization.


## Why

It's impossible to customize the wrapper's style, unless add an additional element to wrap around the component. 